### PR TITLE
fix: update lookup to getType

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,7 +108,7 @@ function httpHandle (req, res){
                     info = false;
                 }
 
-                res.writeHead(200, {'Content-Type': mime.lookup(filename),"Access-Control-Allow-Origin":"*"});
+                res.writeHead(200, {'Content-Type': mime.getType(filename),"Access-Control-Allow-Origin":"*"});
                 if(!config.fixModule||!info) {
                     var more = i==0 && info;
                     more && res.write(getHeader());


### PR DESCRIPTION
module mime@2.x is a breaking change from 1.x as the semver implies. 
lookup() renamed to getType()